### PR TITLE
C++17 filesystem on travis, outdated libstdc++ 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,16 +43,17 @@ jobs:
       dist: bionic
       compiler: clang
       env:
-        - CLANG_VER="9"
+        - CLANG_VER="10"
         - MATRIX_EVAL="CC=clang-${CLANG_VER} && CXX=clang++-${CLANG_VER}"
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-9
+            - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main'
+              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
           packages:
-            - clang-9
-            - libstdc++-9-dev
+            - clang-10
+            - libstdc++-10-dev
             - doxygen
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,17 +42,18 @@ jobs:
     - os: linux
       dist: bionic
       compiler: clang
-      addons:
-        sources:
-          - ubuntu-toolchain-r-test
-          - llvm-toolchain-10
-        packages:
-          - clang-10
-          - libstdc++-10-dev
-          - doxygen
       env:
-          - CLANG_VER="10"
-          - MATRIX_EVAL="CC=clang-${CLANG_VER} && CXX=clang++-${CLANG_VER}"
+        - CLANG_VER="10"
+        - MATRIX_EVAL="CC=clang-${CLANG_VER} && CXX=clang++-${CLANG_VER}"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-10
+          packages:
+            - clang-10
+            - libstdc++-10-dev
+            - doxygen
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
   include:
     - os: osx
       compiler: gcc
-      osx_image: xcode11.2    # includes gcc-9 by default
+      osx_image: xcode11.5    # includes gcc-9 by default
       env:
         # Conan is at: ${HOME}/Library/Python/2.7/bin: we need this in the path
         - PATH="${HOME}/Library/Python/2.7/bin:${PATH}"
@@ -17,7 +17,7 @@ jobs:
         - bash <(curl -s https://codecov.io/bash) -x /usr/bin/gcov-${GCC_VER}
     - os: osx
       compiler: clang
-      osx_image: xcode11.2
+      osx_image: xcode11.5
       env:
         - PATH="${HOME}/Library/Python/2.7/bin:${PATH}"
         - MATRIX_EVAL=""

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,16 +43,16 @@ jobs:
       dist: bionic
       compiler: clang
       env:
-        - CLANG_VER="10"
+        - CLANG_VER="9"
         - MATRIX_EVAL="CC=clang-${CLANG_VER} && CXX=clang++-${CLANG_VER}"
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-10
+            - llvm-toolchain-9
           packages:
-            - clang-10
-            - libstdc++-10-dev
+            - clang-9
+            - libstdc++-9-dev
             - doxygen
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,18 @@ jobs:
     - os: linux
       dist: bionic
       compiler: clang
+      addons:
+        sources:
+          - ubuntu-toolchain-r-test
+          - llvm-toolchain-10
+        packages:
+          - clang-10
+          - libstdc++-10-dev
+          - doxygen
       env:
-        - MATRIX_EVAL="CC=clang && CXX=clang++"
-      addons: { apt: { packages: ['doxygen'] } }
+          - CLANG_VER="10"
+          - MATRIX_EVAL="CC=clang-${CLANG_VER} && CXX=clang++-${CLANG_VER}"
+
 
 
 before_script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ add_library(project_options INTERFACE)
 target_compile_features(project_options INTERFACE cxx_std_17)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+  add_compile_definitions(project_options INTERFACE
+          $<$<AND:$<PLATFORM_ID:Darwin>,$<VERSION_GREATER:$<CXX_COMPILER_VERSION>,8.0>>:-mmacosx-version-min=10.15>)
   option(ENABLE_BUILD_WITH_TIME_TRACE "Enable -ftime-trace to generate time tracing .json files on clang" OFF)
   if (ENABLE_BUILD_WITH_TIME_TRACE)
     add_compile_definitions(project_options INTERFACE -ftime-trace)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(project_options INTERFACE)
 target_compile_features(project_options INTERFACE cxx_std_17)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
-  add_compile_definitions(project_options INTERFACE
+  target_compile_options(project_options INTERFACE
           $<$<AND:$<PLATFORM_ID:Darwin>,$<VERSION_GREATER:$<CXX_COMPILER_VERSION>,8.0>>:-mmacosx-version-min=10.15>)
   option(ENABLE_BUILD_WITH_TIME_TRACE "Enable -ftime-trace to generate time tracing .json files on clang" OFF)
   if (ENABLE_BUILD_WITH_TIME_TRACE)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,7 @@
 #include <docopt/docopt.h>
 
 #include <iostream>
-
+#include <filesystem>
 static constexpr auto USAGE =
   R"(Naval Fate.
 
@@ -36,7 +36,7 @@ int main(int argc, const char **argv)
   for (auto const &arg : args) {
     std::cout << arg.first << arg.second << std::endl;
   }
-
+  std::cout<<"Running from: "<< std::filesystem::current_path();
 
   //Use the default logger (stdout, multi-threaded, colored)
   spdlog::info("Hello, {}!", "World");


### PR DESCRIPTION
Using the `std::filesystem` features caused travis to fail builds on ubuntu and mac with clang giving:

-   `fatal error: 'filesystem' file not found` due to an outdated standard library implementation, which is fixable by adding the newer `libstdc++-10-dev` package in `.travis.yml` 

- `error: 'current_path' is unavailable: introduced in macOS 10.15` which is fixable by introducing `mmacosx-version-min=10.15` into the `CMakeLists.txt`

respectively.
