### PR TITLE
FreeBSD 12.1 (default on Travis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,15 @@ jobs:
       env:
         - MATRIX_EVAL="CC=clang && CXX=clang++"
       addons: { apt: { packages: ['doxygen', 'python3-pip'] } }
+    - os: freebsd
+      compiler: clang
+      env:
+        - MATRIX_EVAL="CC=clang && CXX=clang++"
+      addons:
+        pkg:
+            - py37-pip
+            - conan
+
 
 
 before_script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,10 @@ if(ENABLE_PCH)
     <utility>)
 endif()
 
+# spdlog async wants pthread_create
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 # Set up some extra Conan dependencies based on our needs before loading Conan
 set(CONAN_EXTRA_REQUIRES "")
 set(CONAN_EXTRA_OPTIONS "")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,6 +47,7 @@ target_link_libraries(
   intro
   PRIVATE project_options
           project_warnings
+          Threads::Threads
           CONAN_PKG::docopt.cpp
           CONAN_PKG::fmt
           CONAN_PKG::spdlog)


### PR DESCRIPTION
Travis supports a FreeBSD 12.1 image. It's quite dated, but still useful for testing builds. [Successful run](https://travis-ci.com/github/JeanVEGA/cpp_starter_project/jobs/512657432).