### PR TITLE
Run code format check in Github Actions

### DIFF
--- a/.github/workflows/code-format-check.yml
+++ b/.github/workflows/code-format-check.yml
@@ -3,9 +3,6 @@ name: Code Format Check
 on:
   pull_request:
   push:
-    branches:
-      - main
-      - master
 
 defaults:
   run:

--- a/.github/workflows/code-format-check.yml
+++ b/.github/workflows/code-format-check.yml
@@ -1,0 +1,45 @@
+name: Code Format Check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: 'ubuntu-latest'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install tools
+        run: |
+          pip install cmakelang
+
+      - name: Check cpp code formatting
+        run: |
+          git ls-files |\
+            grep -E '\.(c|cc|C|cii|cpp|cxx|c++|h|hii|hpp|hxx|h++)$' |\
+            xargs clang-format --dry-run --Werror
+
+      - name: Check CMake code formatting
+        run: |
+          git ls-files |\
+            grep -E '(\.cmake$|CMakeLists.txt)' |\
+            xargs cmake-format --check
+
+      - name: Lint CMake code
+        # This step is configured to print all the output that cmake-lint would
+        # generate, but it will not cause a build job failure.
+        # If you need this step to fail when cmake-lint reports issues,
+        # simply remove the `|| true` from the last line.
+        run: |
+          git ls-files |\
+            grep -E '(\.cmake$|CMakeLists.txt)' |\
+            xargs cmake-lint || true

--- a/cmake/Conan.cmake
+++ b/cmake/Conan.cmake
@@ -1,15 +1,11 @@
 macro(run_conan)
   # Download automatically, you can also just copy the conan.cmake file
   if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
-    message(
-      STATUS
-        "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
+    message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
     file(
-      DOWNLOAD
-      "https://raw.githubusercontent.com/conan-io/cmake-conan/v0.16.1/conan.cmake"
+      DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/v0.16.1/conan.cmake"
       "${CMAKE_BINARY_DIR}/conan.cmake"
-      EXPECTED_HASH
-        SHA256=396e16d0f5eabdc6a14afddbcfff62a54a7ee75c6da23f32f7a31bc85db23484
+      EXPECTED_HASH SHA256=396e16d0f5eabdc6a14afddbcfff62a54a7ee75c6da23f32f7a31bc85db23484
       TLS_VERIFY ON)
   endif()
 
@@ -19,11 +15,18 @@ macro(run_conan)
 
   include(${CMAKE_BINARY_DIR}/conan.cmake)
 
-  # Add (or remove) remotes as needed
-  # conan_add_remote(NAME conan-center URL https://conan.bintray.com)
-  conan_add_remote(NAME cci URL https://center.conan.io INDEX 0)
+  # Add (or remove) remotes as needed conan_add_remote(NAME conan-center URL https://conan.bintray.com)
   conan_add_remote(
-    NAME bincrafters URL
+    NAME
+    cci
+    URL
+    https://center.conan.io
+    INDEX
+    0)
+  conan_add_remote(
+    NAME
+    bincrafters
+    URL
     https://bincrafters.jfrog.io/artifactory/api/conan/public-conan)
 
   # For multi configuration generators, like VS and XCode
@@ -41,9 +44,8 @@ macro(run_conan)
     # Detects current build settings to pass into conan
     conan_cmake_autodetect(settings BUILD_TYPE ${TYPE})
 
-    # PATH_OR_REFERENCE ${CMAKE_SOURCE_DIR} is used to tell conan to process
-    # the external "conanfile.py" provided with the project
-    # Alternatively a conanfile.txt could be used 
+    # PATH_OR_REFERENCE ${CMAKE_SOURCE_DIR} is used to tell conan to process the external "conanfile.py" provided with
+    # the project Alternatively a conanfile.txt could be used
     conan_cmake_install(
       PATH_OR_REFERENCE
       ${CMAKE_SOURCE_DIR}

--- a/cmake/Linker.cmake
+++ b/cmake/Linker.cmake
@@ -3,8 +3,8 @@ option(ENABLE_USER_LINKER "Enable a specific linker if available" OFF)
 include(CheckCXXCompilerFlag)
 
 set(USER_LINKER_OPTION
-  "lld"
-  CACHE STRING "Linker to be used")
+    "lld"
+    CACHE STRING "Linker to be used")
 set(USER_LINKER_OPTION_VALUES "lld" "gold" "bfd")
 set_property(CACHE USER_LINKER_OPTION PROPERTY STRINGS ${USER_LINKER_OPTION_VALUES})
 list(
@@ -14,9 +14,8 @@ list(
   USER_LINKER_OPTION_INDEX)
 
 if(${USER_LINKER_OPTION_INDEX} EQUAL -1)
-  message(
-    STATUS
-      "Using custom linker: '${USER_LINKER_OPTION}', explicitly supported entries are ${USER_LINKER_OPTION_VALUES}")
+  message(STATUS "Using custom linker: '${USER_LINKER_OPTION}', explicitly "
+                 "supported entries are ${USER_LINKER_OPTION_VALUES}")
 endif()
 
 function(configure_linker project_name)

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -36,7 +36,8 @@ function(enable_sanitizers project_name)
 
     option(ENABLE_SANITIZER_MEMORY "Enable memory sanitizer" OFF)
     if(ENABLE_SANITIZER_MEMORY AND CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
-      message(WARNING "Memory sanitizer requires all the code (including libc++) to be MSan-instrumented otherwise it reports false positives")
+      message(WARNING "Memory sanitizer requires all the code (including libc++) "
+                      "to be MSan-instrumented otherwise it reports false positives")
       if("address" IN_LIST SANITIZERS
          OR "thread" IN_LIST SANITIZERS
          OR "leak" IN_LIST SANITIZERS)

--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -21,11 +21,7 @@ option(ENABLE_IPO "Enable Interprocedural Optimization, aka Link Time Optimizati
 
 if(ENABLE_IPO)
   include(CheckIPOSupported)
-  check_ipo_supported(
-    RESULT
-    result
-    OUTPUT
-    output)
+  check_ipo_supported(RESULT result OUTPUT output)
   if(result)
     set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
   else()
@@ -39,4 +35,3 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 else()
   message(STATUS "No colored compiler diagnostic set for '${CMAKE_CXX_COMPILER_ID}' compiler.")
 endif()
-

--- a/fuzz_test/fuzz_tester.cpp
+++ b/fuzz_test/fuzz_tester.cpp
@@ -17,6 +17,6 @@
 // cppcheck-suppress unusedFunction symbolName=LLVMFuzzerTestOneInput
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 {
-  fmt::print("Value sum: {}, len{}\n", sum_values(Data,Size), Size);
+  fmt::print("Value sum: {}, len{}\n", sum_values(Data, Size), Size);
   return 0;
 }

--- a/src/imgui/test.cpp
+++ b/src/imgui/test.cpp
@@ -28,7 +28,7 @@ int main()
 
     ImGui::SFML::Update(window, deltaClock.restart());
 
-//    ImGui::ShowDemoWindow();
+    //    ImGui::ShowDemoWindow();
 
     ImGui::Begin("Hello, world!");
     ImGui::Button("Look at this pretty button");

--- a/src/qt/HelloQt.hpp
+++ b/src/qt/HelloQt.hpp
@@ -2,9 +2,8 @@
 
 class HelloQt : public QWidget
 {
-  Q_OBJECT // Very Important, this is all the magic that is needed
-public:
-  explicit HelloQt(QWidget *parent = nullptr);
+  Q_OBJECT// Very Important, this is all the magic that is needed
+    public : explicit HelloQt(QWidget *parent = nullptr);
 
   // No need for a destructor (~HelloQt) here, the parent system makes sure that all the elements that
   // are parented to this is cleaned up

--- a/src/sdl/main.cpp
+++ b/src/sdl/main.cpp
@@ -12,7 +12,6 @@
 #include <cstdlib>
 
 
-
 static void check_audio_driver(const char *name)
 {
   std::cout << "checking for audio driver " << name << " ... ";
@@ -40,7 +39,8 @@ static void check_video_driver(const char *name)
 }
 
 
-int main(int argc, char *argv[]) {
+int main(int argc, char *argv[])
+{
   SDL_version v;
   SDL_GetVersion(&v);
   std::cout << "SDL version " << int(v.major) << "." << int(v.minor) << "." << int(v.patch) << std::endl;
@@ -55,10 +55,10 @@ int main(int argc, char *argv[]) {
 
   SDL_Window *window = NULL;
   SDL_Surface *screenSurface = NULL;
-//  if (SDL_Init(SDL_INIT_EVERYTHING) < 0) {
-//    fprintf(stderr, "could not initialize sdl2: %s\n", SDL_GetError());
-//    return 1;
-//  }
+  //  if (SDL_Init(SDL_INIT_EVERYTHING) < 0) {
+  //    fprintf(stderr, "could not initialize sdl2: %s\n", SDL_GetError());
+  //    return 1;
+  //  }
   window = SDL_CreateWindow(
     "hello_sdl2",
     SDL_WINDOWPOS_UNDEFINED,

--- a/test/catch_main.cpp
+++ b/test/catch_main.cpp
@@ -1,5 +1,3 @@
-#define CATCH_CONFIG_MAIN // This tells the catch header to generate a main
+#define CATCH_CONFIG_MAIN// This tells the catch header to generate a main
 
 #include <catch2/catch.hpp>
-
-


### PR DESCRIPTION
This adds an extra Github Action to perform code format and lint checks on every push. Currently, it causes a failed check if CppCheck finds problems, or if clang-format would make changes to the code, or if cmake-lint disagrees with the style of your CMake code.

There are other ways to accomplish this task. I am concerned that cmake-lint might be too aggressive a tool for this purpose; it may be sufficient to just check if cmake-format would make changes.

Some projects choose to use clang-format and cmake-format in CI in a way that causes a bot to generate PRs to fix code formatting; that's another reasonable option.

The whole point of this PR is to add the `lint-check.yml` file; the changes in the other 9 files are simply a product of running clang-format and cmake-format so that the new checks pass.

**Edit:** This PR has been changed to remove the C++ static analysis workflow; that work can be saved for a future PR, possibly using https://github.com/aminya/setup-cpp when it supports IWYU.