### PR TITLE
updated lgtm badge link and shuffled badge order

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,16 @@
 # cpp_starter_project
 
-[![codecov](https://codecov.io/gh/lefticus/cpp_starter_project/branch/master/graph/badge.svg)](https://codecov.io/gh/lefticus/cpp_starter_project)
-
 [![Build Status](https://travis-ci.org/lefticus/cpp_starter_project.svg?branch=master)](https://travis-ci.org/lefticus/cpp_starter_project)
-
 [![Build status](https://ci.appveyor.com/api/projects/status/ro4lbfoa7n0sy74c/branch/master?svg=true)](https://ci.appveyor.com/project/lefticus/cpp-starter-project/branch/master)
-
 ![CMake](https://github.com/lefticus/cpp_starter_project/workflows/CMake/badge.svg)
-
-[![Language grade: C++](https://img.shields.io/lgtm/grade/cpp/github/lefticus/cpp_starter_project)](https://lgtm.com/projects/g/lefticus/cpp_starter_project/context:cpp)
+[![codecov](https://codecov.io/gh/lefticus/cpp_starter_project/branch/master/graph/badge.svg)](https://codecov.io/gh/lefticus/cpp_starter_project)
+[![Language grade: C++](https://img.shields.io/lgtm/grade/cpp/github/cpp-best-practices/cpp_starter_project)](https://lgtm.com/projects/g/cpp-best-practices/cpp_starter_project/context:cpp)
 
 ## Getting Started
 
 ### Use the Github template
 First, click the green `Use this template` button near the top of this page.
-This will take you to Github's ['Generate Repository'](https://github.com/lefticus/cpp_starter_project/generate) page.
+This will take you to Github's ['Generate Repository'](https://github.com/cpp-best-practices/cpp_starter_project/generate) page.
 Fill in a repository name and short description, and click 'Create repository from template'.
 This will allow you to create a new repository in your Github account,
 prepopulated with the contents of this project.


### PR DESCRIPTION
* adjusted link to the new organization name.
* shuffled and aligned the badges to fit on a line to be a bit more concise.

Some badges (Travis etc) still refer to the 'lefticus' reference. I presume the build system/other GH integrations aren't updated to the new name yet.