### PR TITLE
Remove the last instance of CONAN_PKG

### DIFF
--- a/fuzz_test/CMakeLists.txt
+++ b/fuzz_test/CMakeLists.txt
@@ -1,12 +1,14 @@
 # A fuzz test runs until it finds an error. This particular one is going to rely on libFuzzer.
 #
 
+find_package(fmt)
+
 add_executable(fuzz_tester fuzz_tester.cpp)
 target_link_libraries(
   fuzz_tester
   PRIVATE project_options
           project_warnings
-          CONAN_PKG::fmt
+          fmt::fmt
           -coverage
           -fsanitize=fuzzer,undefined,address)
 target_compile_options(fuzz_tester PRIVATE -fsanitize=fuzzer,undefined,address)


### PR DESCRIPTION
Since #150, we have moved away from the `CONAN_PKG` style of including packages, which helps decouple this project from Conan. There was one last `CONAN_PKG` usage hiding in `fuzz_test/CMakeLists.txt`; this fixes that.

It looks like no one tried to run the fuzz test since #150. Perhaps this target should be included in the CI tests?