### PR TITLE
Remove imgui reference in `StaticAnalysis.cmake`

### DIFF
--- a/cmake/StaticAnalyzers.cmake
+++ b/cmake/StaticAnalyzers.cmake
@@ -10,9 +10,7 @@ if(ENABLE_CPPCHECK)
         --suppress=missingInclude
         --enable=all
         --inline-suppr
-        --inconclusive
-        -i
-        ${CMAKE_SOURCE_DIR}/imgui/lib)
+        --inconclusive)
     if(WARNINGS_AS_ERRORS)
       list(APPEND CMAKE_CXX_CPPCHECK --error-exitcode=2)
     endif()


### PR DESCRIPTION
Fix #140.

It is possible that we will need to pass paths into the ‘-i’ option, as mentioned in https://github.com/cpp-best-practices/cpp_starter_project/issues/140#issuecomment-842090362. But until then, YAGNI, so I did not implement it.