### PR TITLE
ci: use gcovr on windows

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -56,19 +56,17 @@ jobs:
         pip3 install wheel setuptools gcovr
         pip3 install conan --upgrade
 
-    - name: Install / Configure dependencies
-      shell: bash
+    - name: Linux - Fix Conan Path
+      if: runner.os == 'Linux'
       run: |
-        if [ "$RUNNER_OS" == "Linux" ]; then
-          echo "Ubuntu - Fix Conan Path"
           sudo update-alternatives --install /usr/bin/conan conan /home/runner/.local/bin/conan 10
           sudo update-alternatives --config conan
-        elif [ "$RUNNER_OS" == "Windows" ]; then
-          echo "Using chocolatey to install OpenCppCoverage"
+
+    - name: Windows - Install OpenCppCoverage
+      if: runner.os == 'Windows'
+      run: |
           choco install opencppcoverage
-          # Add to Path
           echo "C:/Program Files/OpenCppCoverage" >> $GITHUB_PATH
-        fi;
 
     - name: Configure CMake
       run: |

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -29,10 +29,6 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
-        include:
-        - os: ubuntu-latest
-        - os: windows-latest
-        - os: macos-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -14,6 +14,7 @@ env:
   CONAN_SYSREQUIRES_MODE: enabled
   CONAN_USER_HOME: "${{ github.workspace }}/conan-cache"
   CONAN_USER_HOME_SHORT: "${{ github.workspace }}/conan-cache/short"
+  ENABLE_COVERAGE: ON
 
 # Use a bash shell so we can use the same syntax for environment variable
 # access regardless of the host operating system
@@ -30,13 +31,8 @@ jobs:
         os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
         include:
         - os: ubuntu-latest
-          ENABLE_COVERAGE: ON
         - os: windows-latest
-          # Windows works differently
-          ENABLE_COVERAGE: OFF
         - os: macos-latest
-          ENABLE_COVERAGE: ON
-
 
     steps:
     - uses: actions/checkout@v2
@@ -62,22 +58,16 @@ jobs:
           sudo update-alternatives --install /usr/bin/conan conan /home/runner/.local/bin/conan 10
           sudo update-alternatives --config conan
 
-    - name: Windows - Install OpenCppCoverage
-      if: runner.os == 'Windows'
-      run: |
-          choco install opencppcoverage
-          echo "C:/Program Files/OpenCppCoverage" >> $GITHUB_PATH
 
     - name: Configure CMake
       run: |
-          cmake -S . -B ./build -DCMAKE_BUILD_TYPE:STRING=$BUILD_TYPE -DENABLE_COVERAGE:BOOL=${{ matrix.ENABLE_COVERAGE }}
+          cmake -S . -B ./build -DCMAKE_BUILD_TYPE:STRING=$BUILD_TYPE -DENABLE_COVERAGE:BOOL=${{ env.ENABLE_COVERAGE }}
 
     - name: Build
       # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: cmake --build ./build --config $BUILD_TYPE
 
-    - name: Unix - Test and coverage
-      if: runner.os != 'Windows'
+    - name: Test
       working-directory: ./build
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
@@ -85,13 +75,7 @@ jobs:
           ctest -C $BUILD_TYPE
           gcovr -j $(nproc) --delete --root ../ --print-summary --xml-pretty --xml coverage.xml .
 
-    - name: Windows - Test and coverage
-      if: runner.os == 'Windows'
-      working-directory: ./build
-      run: |
-        OpenCppCoverage.exe --sources cpp_starter_project --export_type cobertura:coverage.xml --cover_children -- ctest -C $BUILD_TYPE
-
-    - name: Publish to codecov
+    - name: Coverage analysis at codecov
       uses: codecov/codecov-action@v2
       with:
         flags: ${{ runner.os }}


### PR DESCRIPTION
A continuation of #165. [gcovr supports Windows](https://www.mankier.com/1/gcovr#Installation) too, and so I don't think we need to use a separate tool for Windows.