### PR TITLE
Fixed minor typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,6 @@ linked here:
 ## Build Instructions
 
 A full build has different steps:
-1) Specifying the compiler using environment variables
 2) Configuring the project
 3) Building the project
 
@@ -304,9 +303,9 @@ CMake will detect which compiler was used to build each of the Conan targets. If
 				[Environment]::SetEnvironmentVariable("CXX", "cl.exe", "User")
 				refreshenv
 
-		  Set the architecture using [vsvarsall](https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=vs-2019#vcvarsall-syntax):
+		  Set the architecture using [vcvarsall](https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=vs-2019#vcvarsall-syntax):
 
-				vsvarsall.bat x64
+				vcvarsall.bat x64
 
 		- clang
 


### PR DESCRIPTION
The line modified was originally written as `vsvarsall` instead of `vcvarsall`. I don't believe that the command was ever named `vsvarsall` due to the fact that the webpage you linked to names it `vcvarsall`.  So thought I would help there as it wasn't something I expected to have the potential to be wrong.