### PR TITLE
Fix coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,16 +53,16 @@ jobs:
           # Add appropriate variables for gcov version required. This will intentionally break
           # if you try to use a compiler that does not have gcov set
           - compiler: gcc
-            gcov: gcov
+            gcov_executable: gcov
           - compiler: llvm
-            gcov: "llvm-cov gcov"
+            gcov_executable: "llvm-cov gcov"
 
           # This exists solely to make sure a non-multiconfig build works
           - os: ubuntu-20.04
             compiler: gcc
             generator: "Unix Makefiles"
             build_type: Debug
-            gcov: gcov
+            gcov_executable: gcov
             developer_mode: On
 
           - os: windows-2022
@@ -145,7 +145,7 @@ jobs:
         # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
         run: |
           ctest -C ${{matrix.build_type}}
-          gcovr -j ${{env.nproc}} --delete --root ../ --print-summary --xml-pretty --xml coverage.xml . --gcov-executable '${{matrix.gcov}}'
+          gcovr -j ${{env.nproc}} --delete --root ../ --print-summary --xml-pretty --xml coverage.xml . --gcov-executable '${{ matrix.gcov_executable }}'
 
       - name: Windows - Test and coverage
         if: runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,13 @@ jobs:
             compiler: gcc
 
         include:
+          # Add appropriate variables for gcov version required. This will intentionally break
+          # if you try to use a compiler that does not have gcov set
+          - compiler: gcc
+            gcov: gcov
+          - compiler: llvm
+            gcov: "llvm-cov gcov"
+
           # This exists solely to make sure a non-multiconfig build works
           - os: ubuntu-20.04
             compiler: gcc
@@ -119,9 +126,11 @@ jobs:
           gcovr: true
           opencppcoverage: true
 
+        # make sure coverage is only enabled for Debug builds, since it sets -O0 to make sure coverage
+        # has meaningful results
       - name: Configure CMake
         run: |
-          cmake -S . -B ./build -G "${{matrix.generator}}" -DCMAKE_BUILD_TYPE:STRING=${{matrix.build_type}} -DENABLE_DEVELOPER_MODE:BOOL=${{matrix.developer_mode}}
+          cmake -S . -B ./build -G "${{matrix.generator}}" -DCMAKE_BUILD_TYPE:STRING=${{matrix.build_type}} -DENABLE_DEVELOPER_MODE:BOOL=${{matrix.developer_mode}} -DOPT_ENABLE_COVERAGE:BOOL=${{ matrix.build_type == 'Debug' }}
 
       - name: Build
         # Execute the build.  You can specify a specific target with "--target <NAME>"
@@ -135,13 +144,13 @@ jobs:
         # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
         run: |
           ctest -C ${{matrix.build_type}}
-          gcovr -j ${{env.nproc}} --delete --root ../ --print-summary --xml-pretty --xml coverage.xml .
+          gcovr -j ${{env.nproc}} --delete --root ../ --print-summary --xml-pretty --xml coverage.xml . --gcov-executable '${{matrix.gcov}}'
 
       - name: Windows - Test and coverage
         if: runner.os == 'Windows'
         working-directory: ./build
         run: |
-          OpenCppCoverage.exe --sources cpp_starter_project --export_type cobertura:coverage.xml --cover_children -- ctest -C ${{matrix.build_type}}
+          OpenCppCoverage.exe --export_type cobertura:coverage.xml --cover_children -- ctest -C ${{matrix.build_type}}
 
       - name: Publish to codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
             compiler: gcc
             generator: "Unix Makefiles"
             build_type: Debug
+            gcov: gcov
             developer_mode: On
 
           - os: windows-2022

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -19,6 +19,6 @@ extraction:
     configure:
       command:
         - mkdir build
-        - cmake -D ENABLE_COVERAGE:BOOL=TRUE -S . -B build
+        - cmake -D OPT_ENABLE_COVERAGE:BOOL=TRUE -D CMAKE_BUILD_TYPE:STRING=Debug  -S . -B build
     index:
       build_command: cmake --build ./build -- -j2

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -19,6 +19,6 @@ extraction:
     configure:
       command:
         - mkdir build
-        - cmake -D OPT_ENABLE_COVERAGE:BOOL=TRUE -D CMAKE_BUILD_TYPE:STRING=Debug  -S . -B build
+        - cmake -D OPT_ENABLE_COVERAGE:BOOL=TRUE -D CMAKE_BUILD_TYPE:STRING=Debug -D ENABLE_DEVELOPER_MODE:BOOL=FALSE  -S . -B build
     index:
       build_command: cmake --build ./build -- -j2

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,8 @@ add_library(catch_main OBJECT catch_main.cpp)
 target_link_libraries(catch_main PUBLIC Catch2::Catch2)
 target_link_libraries(catch_main PRIVATE project_options)
 
+add_test(NAME cli.has_help COMMAND intro --help)
+
 add_executable(tests tests.cpp)
 target_link_libraries(tests PRIVATE project_warnings project_options catch_main)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(catch_main OBJECT catch_main.cpp)
 target_link_libraries(catch_main PUBLIC Catch2::Catch2)
 target_link_libraries(catch_main PRIVATE project_options)
 
+# Provide a simple smoke test to make sure that the CLI works and can display a --help message
 add_test(NAME cli.has_help COMMAND intro --help)
 
 add_executable(tests tests.cpp)


### PR DESCRIPTION
 * Need to make sure opt_enable_coverage is set when appropriate (only for Debug builds, since it overrides optimization settings)
 * Remove explicit sources dir from windows coverage, so that it still works when template project is used
 * Make sure gcov version/executable is set correctly
 * Add simple test of main executable, to show its coverage also

Note: these issues were discovered while using a recent project made from the template. I think most of these issues are long standing. Previously `ENABLE_COVERAGE` was enabled by default, so it happened to work, but Release builds were not doing what we thought they were doing.