### PR TITLE
Add basic versioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,12 @@ include(${_project_options_SOURCE_DIR}/Index.cmake)
 # run_vcpkg()
 
 # Set the project name and language
-project(myproject LANGUAGES CXX C)
+project(
+  myproject
+  VERSION 0.0.1
+  DESCRIPTION "Starter Project With Best Practices for C++"
+  HOMEPAGE_URL "https://github.com/cpp-best-practices/cpp_starter_project"
+  LANGUAGES CXX C)
 
 get_property(BUILDING_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if(BUILDING_MULTI_CONFIG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,11 @@ dynamic_project_options(
 
 target_compile_features(project_options INTERFACE cxx_std_${CMAKE_CXX_STANDARD})
 
+# configure files based on CMake configuration options
+add_subdirectory(configured_files)
+target_include_directories(project_options INTERFACE "${CMAKE_BINARY_DIR}")
+
+
 # Adding the src:
 add_subdirectory(src)
 

--- a/configured_files/CMakeLists.txt
+++ b/configured_files/CMakeLists.txt
@@ -1,0 +1,3 @@
+configure_file("config.hpp.in" "${CMAKE_BINARY_DIR}/configured_files/config.hpp" ESCAPE_QUOTES)
+
+

--- a/configured_files/config.hpp.in
+++ b/configured_files/config.hpp.in
@@ -4,12 +4,12 @@
 // this is a basic example of how a CMake configured file might look
 // in this particular case, we are using it to set the version number of our executable
 namespace myproject {
-static constexpr std::string_view project_name = "@PROJECT_NAME@";
-static constexpr std::string_view project_version = "@PROJECT_VERSION@";
-static constexpr int project_version_major{@PROJECT_VERSION_MAJOR@};
-static constexpr int project_version_minor{@PROJECT_VERSION_MINOR@};
-static constexpr int project_version_patch{@PROJECT_VERSION_PATCH@};
-static constexpr int project_version_tweak{@PROJECT_VERSION_TWEAK@};
-}
+static constexpr std::string_view name = "@PROJECT_NAME@";
+static constexpr std::string_view version = "@PROJECT_VERSION@";
+static constexpr int version_major { @PROJECT_VERSION_MAJOR@ };
+static constexpr int version_minor { @PROJECT_VERSION_MINOR@ };
+static constexpr int version_patch { @PROJECT_VERSION_PATCH@ };
+static constexpr int version_tweak { @PROJECT_VERSION_TWEAK@ };
+}// namespace myproject
 
 #endif

--- a/configured_files/config.hpp.in
+++ b/configured_files/config.hpp.in
@@ -1,0 +1,15 @@
+#ifndef MYPROJECT_CONFIG_HPP
+#define MYPROJECT_CONFIG_HPP
+
+// this is a basic example of how a CMake configured file might look
+// in this particular case, we are using it to set the version number of our executable
+namespace myproject {
+static constexpr std::string_view project_name = "@PROJECT_NAME@";
+static constexpr std::string_view project_version = "@PROJECT_VERSION@";
+static constexpr int project_version_major{@PROJECT_VERSION_MAJOR@};
+static constexpr int project_version_minor{@PROJECT_VERSION_MINOR@};
+static constexpr int project_version_patch{@PROJECT_VERSION_PATCH@};
+static constexpr int project_version_tweak{@PROJECT_VERSION_TWEAK@};
+}
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,8 @@
 #include <docopt/docopt.h>
 #include <spdlog/spdlog.h>
 
+#include <configured_files/config.hpp>
+
 static constexpr auto USAGE =
   R"(Naval Fate.
 
@@ -28,7 +30,9 @@ int main(int argc, const char **argv)
     std::map<std::string, docopt::value> args = docopt::docopt(USAGE,
       { std::next(argv), std::next(argv, argc) },
       true,// show help if requested
-      "Naval Fate 0.0.1");// version string
+      fmt::format("{} {}",
+        myproject::project_name,
+        myproject::project_version));// version string, acquired from config.hpp via CMake
 
     for (auto const &arg : args) { std::cout << arg.first << "=" << arg.second << '\n'; }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,7 +28,7 @@ int main(int argc, const char **argv)
     std::map<std::string, docopt::value> args = docopt::docopt(USAGE,
       { std::next(argv), std::next(argv, argc) },
       true,// show help if requested
-      "Naval Fate 2.0");// version string
+      "Naval Fate 0.0.1");// version string
 
     for (auto const &arg : args) { std::cout << arg.first << "=" << arg.second << '\n'; }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,8 +31,8 @@ int main(int argc, const char **argv)
       { std::next(argv), std::next(argv, argc) },
       true,// show help if requested
       fmt::format("{} {}",
-        myproject::project_name,
-        myproject::project_version));// version string, acquired from config.hpp via CMake
+        myproject::name,
+        myproject::version));// version string, acquired from config.hpp via CMake
 
     for (auto const &arg : args) { std::cout << arg.first << "=" << arg.second << '\n'; }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,9 @@
 #include <docopt/docopt.h>
 #include <spdlog/spdlog.h>
 
+// This file will be generated automatically when you run the CMake configuration step.
+// It creates a namespace called `myproject`.
+// You can modify the source template at `configured_files/config.hpp.in`.
 #include <configured_files/config.hpp>
 
 static constexpr auto USAGE =

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,6 +10,14 @@ target_link_libraries(catch_main PRIVATE project_options)
 # Provide a simple smoke test to make sure that the CLI works and can display a --help message
 add_test(NAME cli.has_help COMMAND intro --help)
 
+# Provide a test to verify that the version being reported from the application
+# matches the version given to CMake. This will be important once you package
+# your program. Real world shows that this is the kind of simple mistake that is easy
+# to make, but also easy to test for.
+add_test(NAME cli.version_matches COMMAND intro --version)
+set_tests_properties(cli.version_matches PROPERTIES PASS_REGULAR_EXPRESSION "${PROJECT_VERSION}")
+
+
 add_executable(tests tests.cpp)
 target_link_libraries(tests PRIVATE project_warnings project_options catch_main)
 


### PR DESCRIPTION
 * set project version
 * update cli example with project version
 * add simple test to verify versions match

Yes, this is probably better handled with a CMake configured file to
make sure things do not get out sync with the main.cpp, but

 * this kind of sanity check is always good and adds no overhead
 * I'm not 100% certain we should put a configured.hpp file in the
   starter project.