### PR TITLE
WIP Feature/add non root user in dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -114,6 +114,9 @@ RUN mkdir -p $(include-what-you-use -print-resource-dir 2>/dev/null)
 RUN ln -s $(readlink -f /usr/lib/clang/${LLVM_VER}/include) \
     $(include-what-you-use -print-resource-dir 2>/dev/null)/include
 
+# Install cmake format package
+RUN python3 -m pip install --upgrade pip cmake_format
+
 ## Cleanup cached apt data we don't need anymore
 RUN apt-get autoremove -y && apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,7 +32,7 @@ RUN python3 -m pip install --upgrade pip setuptools && \
 # By default, anything you run in Docker is done as superuser.
 # Conan runs some install commands as superuser, and will prepend `sudo` to
 # these commands, unless `CONAN_SYSREQUIRES_SUDO=0` is in your env variables.
-ENV CONAN_SYSREQUIRES_SUDO 0
+ENV CONAN_SYSREQUIRES_SUDO 1
 # Some packages request that Conan use the system package manager to install
 # a few dependencies. This flag allows Conan to proceed with these installations;
 # leaving this flag undefined can cause some installation failures.
@@ -129,6 +129,8 @@ ENV CXX=${USE_CLANG:+"clang++"}
 # if CC is null, set it to 'gcc' (or leave as is otherwise).
 ENV CC=${CC:-"gcc"}
 ENV CXX=${CXX:-"g++"}
+
+USER $USERNAME
 
 # Include project
 #ADD . /workspaces/cpp_starter_project

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,8 +2,19 @@
 ARG VARIANT="focal"
 FROM ubuntu:${VARIANT}
 
-# Restate the variant to use it later on in the llvm and cmake installations
-ARG VARIANT
+ARG USERNAME="user"
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Create the user
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    #
+    # [Optional] Add sudo support. Omit if you don't need to install software after connecting.
+    && apt-get update \
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
 
 # Install necessary packages available from standard repos
 RUN apt-get update -qq && export DEBIAN_FRONTEND=noninteractive && \
@@ -40,6 +51,9 @@ RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
 # Set gcc-${GCC_VER} as default gcc
 RUN update-alternatives --install /usr/bin/gcc gcc $(which gcc-${GCC_VER}) 100
 RUN update-alternatives --install /usr/bin/g++ g++ $(which g++-${GCC_VER}) 100
+
+# Restate the variant to use it later on in the llvm and cmake installations
+ARG VARIANT
 
 ARG LLVM_VER="13"
 # Add clang-${LLVM_VER}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,14 +5,13 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		// Update 'VARIANT' to pick an Ubuntu OS version. Options: [bionic, focal]. Default: focal
+		// Update 'USERNAME' to set the non-root user name. Also use that same name in "remoteUser" setting to login with VSCode to the docker. Default: user
 		// Update 'GCC_VER' to pick a gcc and g++ version. Options: [7, 8, 9, 10, 11]. Default: 11
 		// Update 'LLVM_VER' to pick clang version. Options: [10, 11, 12, 13]. Default: 13
 		// Update 'USE_CLANG' to set clang as the default C and C++ compiler. Options: [1, null]. Default null
-		// "args": {
-		// 	"VARIANT": "focal",
-		// 	"GCC_VER": "11",
-		// 	"LLVM_VER": "13"
-		// }
+		"args": {
+			"USERNAME": "vscode"
+		}
 	},
 	"runArgs": [
 		"--cap-add=SYS_PTRACE",
@@ -41,7 +40,7 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	//"postCreateCommand": "uname -a",
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	//"remoteUser": "vscode",
+	"remoteUser": "vscode",
 	"workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/${localWorkspaceFolderBasename},type=bind,consistency=delegated",
 	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
 	"features": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,6 +30,7 @@
 		"twxs.cmake",
 		"ms-vscode.cpptools-themes",
 		"cschlosser.doxdocgen",
+		"gitkraken.gitkraken-authentication",
 		"eamodio.gitlens",
 		"ms-python.python",
 		"ms-python.vscode-pylance",


### PR DESCRIPTION
Make docker dev container safer to use by logging to a non-root user as described here https://aka.ms/vscode-remote/containers/non-root .
Clean up some defaulted arguments.
Install cmake_format in the container