### PR TITLE
configured files: installing generated header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # This means that all analysis (sanitizers, static analysis)
 # is enabled and all warnings are treated as errors
 # if you want to switch this behavior, change TRUE to FALSE
-set(ENABLE_DEVELOPER_MODE
-    TRUE
-    CACHE BOOL "Enable 'developer mode'")
+option (ENABLE_DEVELOPER_MODE "Enable 'developer mode'" ON)
 
 # Change this to false if you want to disable warnings_as_errors in developer mode
 set(OPT_WARNINGS_AS_ERRORS_DEVELOPER_DEFAULT TRUE)

--- a/configured_files/CMakeLists.txt
+++ b/configured_files/CMakeLists.txt
@@ -2,6 +2,31 @@
 # A very simple example of a configured file that might need to be
 # converted to one that is publicly installed in the case that
 # you are developing a library
-configure_file("config.hpp.in" "${CMAKE_BINARY_DIR}/configured_files/include/internal_use_only/config.hpp" ESCAPE_QUOTES)
 
+set (configured_file_dir "${CMAKE_BINARY_DIR}/configured_files/include/internal_use_only")
 
+set (configured_file "${configured_file_dir}/config.hpp")
+
+configure_file ("config.hpp.in" "${configured_file}" ESCAPE_QUOTES @ONLY)
+
+include (GNUInstallDirs)
+
+set (file_install_dir "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}")
+
+install (FILES "${configured_file}" 
+		 DESTINATION "${file_install_dir}"
+		 COMPONENT "${PROJECT_NAME}")
+
+add_library (configured_header_interface INTERFACE)
+
+target_include_directories (configured_header_interface INTERFACE 
+							$<BUILD_INTERFACE:${configured_file_dir}>
+							$<INSTALL_INTERFACE:${file_install_dir}>)
+
+target_sources (configured_header_interface INTERFACE
+				$<BUILD_INTERFACE:${configured_file}>
+				$<INSTALL_INTERFACE:${file_install_dir}/config.hpp>)
+
+unset (configured_file)
+unset (configured_file_dir)
+unset (file_install_dir)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,9 +11,7 @@ target_link_libraries(
   intro
   PRIVATE project_options
           project_warnings
+          configured_header_interface
           docopt::docopt
           fmt::fmt
           spdlog::spdlog)
-
-target_include_directories(intro PRIVATE "${CMAKE_BINARY_DIR}/configured_files/include")
-


### PR DESCRIPTION
This adds an example of installing the generated header file, and using generator expressions to use the header in the binary directory when building, or the header in the install tree when linking to the installed project. This also adds an example of using an interface library to express usage requirements.