### PR TITLE
Fix conan install by specifiyng zlib version

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -7,6 +7,7 @@ fmt/8.1.1
 spdlog/1.9.2
 sdl/2.0.20
 fltk/1.3.8
+zlib/1.2.12
 
 [generators]
 cmake_find_package_multi


### PR DESCRIPTION
- fixes #215
- 'fltk/1.3.8' requires 'zlib/1.2.11'
- 'libxml2/2.9.12' requires 'zlib/1.2.12'
- to resolve the conflict, specify 'zlib/1.2.12' in the conanfile